### PR TITLE
Update Azure Functions packages to latest versions

### DIFF
--- a/code/csharp/functions/functions.csproj
+++ b/code/csharp/functions/functions.csproj
@@ -8,12 +8,12 @@
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.20.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.16.4" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.21.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">


### PR DESCRIPTION
This pull request includes updates to the `code/csharp/functions/functions.csproj` file, specifically upgrading several package references to newer versions.

Fixed #4 

Package updates:

* Upgraded `Microsoft.Azure.Functions.Worker` from version `1.20.1` to `2.0.0`.
* Upgraded `Microsoft.Azure.Functions.Worker.Extensions.Http` from version `3.1.0` to `3.3.0`.
* Upgraded `Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore` from version `1.2.0` to `2.0.1`.
* Upgraded `Microsoft.Azure.Functions.Worker.Sdk` from version `1.16.4` to `2.0.1`.
* Upgraded `Microsoft.ApplicationInsights.WorkerService` from version `2.21.0` to `2.23.0`.
* Upgraded `Microsoft.Azure.Functions.Worker.ApplicationInsights` from version `1.1.0` to `2.0.0`.